### PR TITLE
Fix ReCaptcha version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "intervention/imagecache": "dev-master",
         "mcamara/laravel-localization": "0.14.*",
         "dimsav/laravel-translatable": "4.2.*",
-        "greggilbert/recaptcha": "dev-master",
+        "greggilbert/recaptcha": "1.*",
         "loic-sharma/profiler": "1.1.*",
 
         "lavalite/user": "2.2.*",


### PR DESCRIPTION
ReCaptcha dev-master requires Laravel 5 now.
As README says: 
> (Looking for a Laravel 4 version? Pull the latest 1.x tag.)