### PR TITLE
Fix teeplus/theme version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "laravel/framework": "4.2.*",
         "cartalyst/sentry": "dev-master",
         "anahkiasen/former": "dev-master",
-        "teepluss/theme": "dev-master",
+        "teepluss/theme": "1.*",
         "intervention/imagecache": "dev-master",
         "mcamara/laravel-localization": "0.14.*",
         "dimsav/laravel-translatable": "4.2.*",


### PR DESCRIPTION
master uses Laravel 5 now. `composer install` fails.
> For Laravel 4, please use the v1.x branch!