### PR TITLE
.gitignore for JetBrains IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@
 composer.develop.json
 composer.develop.lock
 composer.lock
+
+
+###
+### PhpStorm ###
+###
+.idea/
+*.iml
+# File-based project format:
+*.iws


### PR DESCRIPTION
Added rules in .gitignore to ignore JetBrains IDE like PhpStorm.
