### PR TITLE
Add vscode-made directory  to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ Homestead.yaml
 composer.lock
 package-lock.json
 
+# VScode
+~/
+ 
 # PhpStorm 
 .idea/
 *.iml


### PR DESCRIPTION
When working with Visual Studio Code editor it creates `~/` directory  which should be ignored!
