### PR TITLE
Added namespace for Str

### DIFF
--- a/app/Http/Controllers/User/UserResourceController.php
+++ b/app/Http/Controllers/User/UserResourceController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\User;
 
+use Illuminate\Support\Str;
 use Litepie\Roles\Interfaces\PermissionRepositoryInterface;
 use Litepie\Roles\Interfaces\RoleRepositoryInterface;
 use App\Http\Controllers\ResourceController as BaseController;


### PR DESCRIPTION
This fix adds the not loaded namespace for `Str::random(60);` on line 26 in file `app/Http/Controllers/User/UserResourceController.php`